### PR TITLE
kf4cic: do not build libavb if BOARD_AVB_ENABLE not set

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -557,7 +557,10 @@ LOCAL_C_INCLUDES += $(addprefix $(LOCAL_PATH)/,avb)
 ifeq ($(TARGET_USE_TRUSTY),true)
     LOCAL_STATIC_LIBRARIES += libqltipc-$(TARGET_BUILD_VARIANT)
 endif
-LOCAL_STATIC_LIBRARIES += libavb_kernelflinger-$(TARGET_BUILD_VARIANT)
+
+ifeq ($(BOARD_AVB_ENABLE),true)
+    LOCAL_STATIC_LIBRARIES += libavb_kernelflinger-$(TARGET_BUILD_VARIANT)
+endif
 
 keys4cic_intermediates := $(call intermediates-dir-for,EFI,keys)
 


### PR DESCRIPTION
if BOARD_AVB_ENABLE isn't set, libavb do not need to be built

Tracked-On: OAM-88398
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>