### PR TITLE
KF: clear sensitive data after used

### DIFF
--- a/libfastboot/keybox_provision.c
+++ b/libfastboot/keybox_provision.c
@@ -20,6 +20,7 @@
 #include "rpmb_storage.h"
 #include <aes_gcm.h>
 #include <keybox_provision.h>
+#include <openssl/crypto.h>
 
 static struct gcm_key attkb_key = {0};
 static encrypted_attkb_t enc_kb;
@@ -110,7 +111,7 @@ static EFI_STATUS write_attkb_data_real(UINT8 *start_kb_addr, UINTN write_sz)
 	data_addr = data_addr + (blk_cnt * RPMB_BLOCK_SIZE);
 
 	if (remain) {
-		memset(rpmb_buffer, 0, RPMB_BLOCK_SIZE);
+		OPENSSL_cleanse(rpmb_buffer, RPMB_BLOCK_SIZE);
 		memcpy(rpmb_buffer, data_addr, remain);
 		ret = write_rpmb_data(NULL, 1, blk_addr, data_addr, rpmb_key, &rpmb_result);
 		debug(L"ret=%d, rpmb_result=%d", ret, rpmb_result);
@@ -121,7 +122,7 @@ static EFI_STATUS write_attkb_data_real(UINT8 *start_kb_addr, UINTN write_sz)
 	}
 exit:
 	//clear the rpmb key
-	memset(rpmb_key, 0, sizeof(rpmb_key));
+	OPENSSL_cleanse(rpmb_key, sizeof(rpmb_key));
 #endif
 	return ret;
 }
@@ -190,8 +191,8 @@ EFI_STATUS flash_keybox(VOID *data, UINTN size)
 exit:
 	//clean up the keybox plaintext and encrypted data including metadata
 	//information before free the memory
-	memset(data, 0, size);
-	memset(start_kb_addr, 0, total_sz);
+	OPENSSL_cleanse(data, size);
+	OPENSSL_cleanse(start_kb_addr, total_sz);
 	FreePool(start_kb_addr);
 	return ret;
 }

--- a/libkernelflinger/rpmb/rpmb_storage.c
+++ b/libkernelflinger/rpmb/rpmb_storage.c
@@ -34,6 +34,7 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include <openssl/sha.h>
+#include <openssl/crypto.h>
 #include "protocol/Mmc.h"
 #include "protocol/SdHostIo.h"
 #include "sdio.h"
@@ -144,13 +145,13 @@ EFI_STATUS get_rpmb_derived_key(OUT UINT8 **d_key, OUT UINT8 *number_d_key)
 void clear_rpmb_key(void)
 {
 	if (derived_key && number_derived_key) {
-		memset(derived_key, 0, number_derived_key * RPMB_KEY_SIZE);
+		OPENSSL_cleanse(derived_key, number_derived_key * RPMB_KEY_SIZE);
 		number_derived_key = 0;
 		FreePool(derived_key);
 		derived_key = NULL;
 	}
 
-	memset(rpmb_key, 0, RPMB_KEY_SIZE);
+	OPENSSL_cleanse(rpmb_key, RPMB_KEY_SIZE);
 }
 
 void set_rpmb_key(UINT8 *key)
@@ -644,7 +645,7 @@ static EFI_STATUS read_rpmb_keybox_magic_simulate(UINT16 offset, void *buffer)
 	debug(L"ret=%d", ret);
 	/*gpt not updated, force success*/
 	if (ret == EFI_NOT_FOUND) {
-		memset(buffer, 0, sizeof(uint32_t));
+		OPENSSL_cleanse(buffer, sizeof(uint32_t));
 		return EFI_SUCCESS;
 	}
 
@@ -723,7 +724,7 @@ EFI_STATUS rpmb_key_init(void)
 	error(L"Init RPMB key successfully");
 
 err_get_rpmb_key:
-	memset(key, 0, sizeof(key));
+	OPENSSL_cleanse(key, sizeof(key));
 
 	return ret;
 }

--- a/libkernelflinger/security_abl.c
+++ b/libkernelflinger/security_abl.c
@@ -33,6 +33,7 @@
 #include <lib.h>
 #include <openssl/hkdf.h>
 #include <openssl/mem.h>
+#include <openssl/crypto.h>
 #include "security_interface.h"
 #include "rpmb_storage.h"
 #include "life_cycle.h"
@@ -137,7 +138,7 @@ out:
 		efi_perror(ret, L"Failed to generate the rpmb key");
 	}
 
-	memset(rpmb_key, 0, sizeof(rpmb_key));
+	OPENSSL_cleanse(rpmb_key, sizeof(rpmb_key));
 	return ret;
  }
 #else


### PR DESCRIPTION
Change-Id: I243a409cafcad944b5d43cd9b8c0fa1d729f5d7c
Tracked-On: OAM-88533
Signed-off-by: Huang Yang <yang.huang@intel.com>