### PR TITLE
Kerneflinger: set bootloader to locked state on the first boot

### DIFF
--- a/include/tpm2_security.h
+++ b/include/tpm2_security.h
@@ -56,6 +56,8 @@ EFI_STATUS write_device_state_tpm2(UINT8 state);
 EFI_STATUS read_rollback_index_tpm2(size_t rollback_index_slot, uint64_t *out_rollback_index);
 EFI_STATUS write_rollback_index_tpm2(size_t rollback_index_slot, uint64_t rollback_index);
 
+BOOLEAN tpm2_get_bootloader_init_state(void);
+
 #ifndef USER
 EFI_STATUS tpm2_show_index(UINT32 index, uint8_t *out_buffer, UINTN out_buffer_size);
 EFI_STATUS tpm2_delete_index(UINT32 index);

--- a/include/vars.h
+++ b/include/vars.h
@@ -114,6 +114,8 @@ BOOLEAN get_oemvars_update(void);
 EFI_STATUS set_oemvars_update(BOOLEAN updated);
 BOOLEAN get_slot_fallback(void);
 EFI_STATUS set_slot_fallback(BOOLEAN enabled);
+/* return TRUE on device initialize, FALSE on un-initialize */
+BOOLEAN check_device_init_state(void);
 
 enum device_state {
 	UNKNOWN_STATE = -1,

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -1120,6 +1120,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	VOID *bootimage = NULL;
 	BOOLEAN oneshot = FALSE;
 	BOOLEAN lock_prompted = FALSE;
+	BOOLEAN init_state;
 	enum boot_target boot_target = NORMAL_BOOT;
 	UINT8 boot_state = BOOT_STATE_GREEN;
 	VBDATA *vb_data = NULL;
@@ -1166,6 +1167,8 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	uefi_check_upgrade(g_loaded_image, BOOTLOADER_LABEL, KFUPDATE_FILE,
 			BOOTLOADER_FILE, BOOTLOADER_FILE_BAK, KFSELF_FILE, KFBACKUP_FILE);
 
+	init_state = check_device_init_state();
+
 #ifdef USE_TPM
 	if (!is_live_boot()) {
 		ret = tpm2_init();
@@ -1175,6 +1178,9 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 		}
 	}
 #endif
+
+	if (!init_state)
+		set_current_state(LOCKED);
 
 	ret = set_device_security_info(NULL);
 	if (EFI_ERROR(ret)) {

--- a/libkernelflinger/tpm2_security.c
+++ b/libkernelflinger/tpm2_security.c
@@ -1012,6 +1012,22 @@ EFI_STATUS write_rollback_index_tpm2(size_t rollback_index_slot, uint64_t rollba
 	return ret;
 }
 
+BOOLEAN tpm2_get_bootloader_init_state(void)
+{
+	EFI_STATUS ret;
+	TPM2B_NV_PUBLIC NvPublic;
+	TPM2B_NAME NvName;
+
+	ret = Tpm2NvReadPublic(NV_INDEX_BOOTLOADER, &NvPublic, &NvName);
+	if (EFI_ERROR(ret)) {
+		if (ret == EFI_NOT_FOUND) {
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
 EFI_STATUS tpm2_init(void)
 {
 	EFI_STATUS ret;

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -383,6 +383,26 @@ EFI_STATUS refresh_current_state(void)
 	return EFI_SUCCESS;
 }
 
+BOOLEAN check_device_init_state(void)
+{
+#ifndef USE_TPM
+	UINT8 stored_state;
+#endif
+
+	if (is_live_boot())
+		return TRUE;
+
+#ifdef USE_TPM
+	return tpm2_get_bootloader_init_state();
+#else
+	if (EFI_NOT_FOUND == read_device_state_efi(&stored_state)) {
+		return FALSE;
+	}
+
+	return TRUE;
+#endif
+}
+
 #ifndef USER
 EFI_STATUS reprovision_state_vars(VOID)
 {


### PR DESCRIPTION
Tracked-On: OAM-94425
Signed-off-by: Chen Gang G <gang.g.chen@intel.com>