### PR TITLE
[Don't Merge] Show the host ip in fastboot

### DIFF
--- a/include/vars.h
+++ b/include/vars.h
@@ -144,6 +144,7 @@ char *get_property_name(void);
 char *get_property_model(void);
 #endif
 char *get_device_id(void);
+char *get_host_ip(void);
 CHAR16 *boot_state_to_string(UINT8 boot_state);
 #ifndef USER
 EFI_STATUS reprovision_state_vars(VOID);

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -791,6 +791,21 @@ char *get_device_id(void)
 }
 #endif
 
+/* This is a WA, we use the asset field of type_chassis to transfer the
+ * host ip to bootloader.*/
+char *get_host_ip(void)
+{
+	static char host_ip[ANDROID_PROP_VALUE_MAX];
+
+	if (!host_ip[0]) {
+        SMBIOS_TO_BUFFER(host_ip, TYPE_CHASSIS, AssetTag);
+		CDD_clean_string(host_ip);
+		debug(L"Detected host ip '%a'", host_ip);
+	}
+
+	return host_ip;
+}
+
 char *get_serialno_var()
 {
 	CHAR8 *data;


### PR DESCRIPTION
This is a W/A, we currently use the asset field of smbios'
type_chassis struct to pass the host ip to bootloader.

Tracked-On: OAM-96182
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>