### PR TITLE
Add boot_patchlevel

### DIFF
--- a/libqltipc/interface/include/interface/keymaster/keymaster.h
+++ b/libqltipc/interface/include/interface/keymaster/keymaster.h
@@ -56,7 +56,8 @@ enum keymaster_command {
 	KM_SET_BOOT_PARAMS               = (0x1000 << KEYMASTER_REQ_SHIFT),
 	KM_PROVISION_KEYBOX              = (0x1001 << KEYMASTER_REQ_SHIFT),
 	KM_SET_ATTESTATION_KEY           = (0x2000 << KEYMASTER_REQ_SHIFT),
-	KM_APPEND_ATTESTATION_CERT_CHAIN = (0x3000 << KEYMASTER_REQ_SHIFT)
+	KM_APPEND_ATTESTATION_CERT_CHAIN = (0x3000 << KEYMASTER_REQ_SHIFT),
+	KM_CONFIGURE_BOOT_PATCHLEVEL     = (0xd0000 << KEYMASTER_REQ_SHIFT)
 };
 
 typedef enum {
@@ -218,6 +219,16 @@ struct km_boot_params {
     uint32_t verified_boot_hash_size;
     const uint8_t* verified_boot_hash;
 } TRUSTY_ATTR_PACKED;
+
+/**
+ * km_boot_patchlevel - request format for KM_SET_BOOT_PARAMS.
+ *
+ * @boot_patchlevel: boot patch level from Android image header
+ */
+struct km_boot_patchlevel {
+    uint32_t boot_patchlevel;
+} TRUSTY_ATTR_PACKED;
+
 
 /**
  * km_attestation_data - request format for KM_SET_ATTESTION_KEY.

--- a/libqltipc/ql-tipc/include/trusty/keymaster.h
+++ b/libqltipc/ql-tipc/include/trusty/keymaster.h
@@ -65,6 +65,13 @@ int trusty_set_boot_params(uint32_t os_version, uint32_t os_patchlevel,
                            uint32_t verified_boot_hash_size);
 
 /*
+ * Config Keymaster boot patchlevel. Returns one of trusty_err.
+ *
+ * @boot_patchlevel: Boot patch level from Android image header
+ */
+int trusty_config_boot_patchlevel(uint32_t boot_patchlevel);
+
+/*
  * Set Keymaster attestation key. Returns one of trusty_err.
  *
  * @key: buffer containing key

--- a/libqltipc/ql-tipc/include/trusty/keymaster_serializable.h
+++ b/libqltipc/ql-tipc/include/trusty/keymaster_serializable.h
@@ -60,6 +60,14 @@ int km_boot_params_serialize(const struct km_boot_params *params, uint8_t **out,
                              uint32_t *out_size);
 
 /**
+ * Serializes a km_boot_patchlevel structure. On success, allocates |*out_size|
+ * bytes to |*out| and writes the serialized |params| to |*out|. Caller takes
+ * ownership of |*out|. Returns one of trusty_err.
+ */
+int km_boot_patchlevel_serialize(const struct km_boot_patchlevel *params, uint8_t **out,
+                             uint32_t *out_size);
+
+/**
  * Serializes a km_attestation_data structure. On success, allocates |*out_size|
  * bytes to |*out| and writes the serialized |data| to |*out|. Caller takes
  * ownership of |*out|. Returns one of trusty_err.

--- a/libqltipc/ql-tipc/keymaster_serializable.c
+++ b/libqltipc/ql-tipc/keymaster_serializable.c
@@ -76,6 +76,23 @@ int km_boot_params_serialize(const struct km_boot_params *params, uint8_t** out,
     return TRUSTY_ERR_NONE;
 }
 
+int km_boot_patchlevel_serialize(const struct km_boot_patchlevel *params, uint8_t** out,
+                             uint32_t *out_size)
+{
+    if (!out || !params || !out_size) {
+        return TRUSTY_ERR_INVALID_ARGS;
+    }
+    *out_size = (sizeof(params->boot_patchlevel));
+    *out = trusty_calloc(*out_size, 1);
+    if (!*out) {
+        return TRUSTY_ERR_NO_MEMORY;
+    }
+    
+    append_uint32_to_buf(*out, params->boot_patchlevel);
+
+    return TRUSTY_ERR_NONE;
+}
+
 int km_attestation_data_serialize(const struct km_attestation_data *data,
                                  uint8_t** out, uint32_t *out_size)
 {


### PR DESCRIPTION
Pass boot_patchlevel to trusty.

Boot_patchlevel specifies the kernel image security patch level that must be installed on the device for a key to be used. The value appears in the form YYYYMMDD, representing the date of the system security patch. For example, if a key were generated on an Android device with the system's Oct 1, 2010 security patch installed, this value would be 20101001.

Tracked-On: OAM-99223
Signed-off-by: yuxincui <yuxin.cui@intel.com>