### PR TITLE
Enhance to support flash two files together

### DIFF
--- a/installer.c
+++ b/installer.c
@@ -594,7 +594,7 @@ static void installer_flash_cmd(INTN argc, CHAR8 **argv)
 	for (int i = 0; i <  num; i++)
 		numname[i] = NULL;
 
-	if (argc > 4) {
+	if (argc > 3) {
 		argc = 2;
 		for (int i = 0; i <  num; i++) {
 			numname[i] = stra_to_str(argv[i+2]);


### PR DESCRIPTION
The feature support 3 part files together at least before, cover the file will split into two parts which is
bigger than 4G but less than 8G
such as:
    flash super super.img.part01 super.img.part02

Tracked-On: OAM-99747
Signed-off-by: Ai, Ting <ting.a.ai@intel.com>