### PR TITLE
Add implementation of attestation ids in the bootloader

### DIFF
--- a/include/security.h
+++ b/include/security.h
@@ -43,8 +43,9 @@
 #define BOOT_TARGET_SIZE         32
 #define BOOT_SIGNATURE_MAX_SIZE  4096
 #define ROT_DATA_STRUCT_VERSION2 0x02
+#define ATTESTATION_ID_MAX_LENGTH 64
 
-#define SETUP_MODE_VAR	        L"SetupMode"
+#define SETUP_MODE_VAR          L"SetupMode"
 #define SECURE_BOOT_VAR         L"SecureBoot"
 
 BOOLEAN is_platform_secure_boot_enabled(VOID);
@@ -101,5 +102,36 @@ EFI_STATUS raw_pub_key_sha256(
         IN const UINT8 *pub_key,
         IN UINTN pub_key_len,
         OUT UINT8 **hash_p);
+
+/* Structure for Attestation_ids info
+*/
+struct attestation_ids_t{
+        UINT32 brandSize;
+        UINT8 brand[ATTESTATION_ID_MAX_LENGTH];
+
+        UINT32 deviceSize;
+        UINT8 device[ATTESTATION_ID_MAX_LENGTH];
+
+        UINT32 modelSize;
+        UINT8 model[ATTESTATION_ID_MAX_LENGTH];
+
+        UINT32 manufacturerSize;
+        UINT8 manufacturer[ATTESTATION_ID_MAX_LENGTH];
+
+        UINT32 nameSize;
+        UINT8 name[ATTESTATION_ID_MAX_LENGTH];
+
+        UINT32 serialSize;
+        UINT8 serial[ATTESTATION_ID_MAX_LENGTH];
+} ;
+
+/* Update the struct attestation_ids for startup_information */
+EFI_STATUS update_attestation_ids(IN VOID *vendorbootimage);
+
+/* Initialize the struct attestation_ids for startup_information */
+EFI_STATUS init_attestation_ids();
+
+/* Return attestation ids instance pointer*/
+struct attestation_ids_t *get_attestation_ids();
 
 #endif

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -946,6 +946,12 @@ static EFI_STATUS load_image(VOID *bootimage, VOID *vendorbootimage, UINT8 boot_
 			die();
 		}
 
+                ret = update_attestation_ids(vendorbootimage);
+                if (EFI_ERROR(ret)) {
+                        efi_perror(ret, L"Unable to get the attestation ids for trusty");
+                        die();
+                }
+
 		set_boottime_stamp(TM_LOAD_TOS_DONE);
 		ret = start_trusty(tosimage);
 		if (EFI_ERROR(ret)) {

--- a/kf4cic.c
+++ b/kf4cic.c
@@ -290,6 +290,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 	}
 
 	init_rot_data(boot_state);
+        init_attestation_ids();
 
 #ifdef USE_TRUSTY
 	debug(L"TRUSTY enabled...\n");

--- a/libqltipc/interface/include/interface/keymaster/keymaster.h
+++ b/libqltipc/interface/include/interface/keymaster/keymaster.h
@@ -57,6 +57,7 @@ enum keymaster_command {
 	KM_PROVISION_KEYBOX              = (0x1001 << KEYMASTER_REQ_SHIFT),
 	KM_SET_ATTESTATION_KEY           = (0x2000 << KEYMASTER_REQ_SHIFT),
 	KM_APPEND_ATTESTATION_CERT_CHAIN = (0x3000 << KEYMASTER_REQ_SHIFT),
+	KM_SET_ATTESTATION_IDS           = (0xc000 << KEYMASTER_REQ_SHIFT),
 	KM_CONFIGURE_BOOT_PATCHLEVEL     = (0xd0000 << KEYMASTER_REQ_SHIFT)
 };
 
@@ -229,6 +230,44 @@ struct km_boot_patchlevel {
     uint32_t boot_patchlevel;
 } TRUSTY_ATTR_PACKED;
 
+/**
+ * km_attestation_ids - request format for KM_SET_ATTESTATION_IDS.
+ *
+ * @brand_size: size of brand
+ * @brand: brand from vendor boot header
+ * @device_size: size of device
+ * @device: device from vendor boot header
+ * @product_size: size of name
+ * @product: name from vendor boot header
+ * @serial_size: size of serial
+ * @serial: serial number from DMI
+ * @imei_size: size of imei
+ * @imei: imei information
+ * @meid_size: size of meid
+ * @meid: meid information
+ * @manufacturer_size: size of manufacturer
+ * @manufacturer: manufacturer from vendor boot header
+ * @model_size: size of model
+ * @model: model from vendor boot header
+ */
+struct km_attestation_ids {
+    uint32_t brand_size;
+    const uint8_t *brand;
+    uint32_t device_size;
+    const uint8_t *device;
+    uint32_t product_size;
+    const uint8_t *product;
+    uint32_t serial_size;
+    const uint8_t *serial;
+    uint32_t imei_size;
+    const uint8_t *imei;
+    uint32_t meid_size;
+    const uint8_t *meid;
+    uint32_t manufacturer_size;
+    const uint8_t *manufacturer;
+    uint32_t model_size;
+    const uint8_t *model;
+} TRUSTY_ATTR_PACKED;
 
 /**
  * km_attestation_data - request format for KM_SET_ATTESTION_KEY.

--- a/libqltipc/ql-tipc/include/trusty/keymaster.h
+++ b/libqltipc/ql-tipc/include/trusty/keymaster.h
@@ -72,6 +72,43 @@ int trusty_set_boot_params(uint32_t os_version, uint32_t os_patchlevel,
 int trusty_config_boot_patchlevel(uint32_t boot_patchlevel);
 
 /*
+ * Set Keymaster attestation ids. Returns one of trusty_err.
+ *
+ * @brand: brand from vendor boot header
+ * @brand_size: size of brand
+ * @device: device from vendor boot header
+ * @device_size: size of device
+ * @product: name from vendor boot header
+ * @product_size: size of name
+ * @serial: serial number from DMI
+ * @serial_size: size of serial
+ * @imei: imei information
+ * @imei_size: size of imei
+ * @meid: meid information
+ * @meid_size: size of meid
+ * @manufacturer: manufacturer from vendor boot header
+ * @manufacturer_size: size of manufacturer
+ * @model: model from vendor boot header
+ * @model_size: size of model
+ */
+int trusty_set_attestation_ids(const uint8_t *brand,
+                               uint32_t brand_size,
+                               const uint8_t *device,
+                               uint32_t device_size,
+                               const uint8_t *product,
+                               uint32_t product_size,
+                               const uint8_t *serial,
+                               uint32_t serial_size,
+                               const uint8_t *imei,
+                               uint32_t imei_size,
+                               const uint8_t *meid,
+                               uint32_t meid_size,
+                               const uint8_t *manufacturer,
+                               uint32_t manufacturer_size,
+                               const uint8_t *model,
+                               uint32_t model_size);
+
+/*
  * Set Keymaster attestation key. Returns one of trusty_err.
  *
  * @key: buffer containing key

--- a/libqltipc/ql-tipc/include/trusty/keymaster_serializable.h
+++ b/libqltipc/ql-tipc/include/trusty/keymaster_serializable.h
@@ -68,6 +68,14 @@ int km_boot_patchlevel_serialize(const struct km_boot_patchlevel *params, uint8_
                              uint32_t *out_size);
 
 /**
+ * Serializes a km_attestation_ids structure. On success, allocates |*out_size|
+ * bytes to |*out| and writes the serialized |params| to |*out|. Caller takes
+ * ownership of |*out|. Returns one of trusty_err.
+ */
+int km_attestation_ids_serialize(const struct km_attestation_ids *params, uint8_t **out,
+                             uint32_t *out_size);
+
+/**
  * Serializes a km_attestation_data structure. On success, allocates |*out_size|
  * bytes to |*out| and writes the serialized |data| to |*out|. Caller takes
  * ownership of |*out|. Returns one of trusty_err.

--- a/libqltipc/ql-tipc/keymaster_serializable.c
+++ b/libqltipc/ql-tipc/keymaster_serializable.c
@@ -93,6 +93,47 @@ int km_boot_patchlevel_serialize(const struct km_boot_patchlevel *params, uint8_
     return TRUSTY_ERR_NONE;
 }
 
+int km_attestation_ids_serialize(const struct km_attestation_ids *params, uint8_t** out,
+                             uint32_t *out_size)
+{
+    uint8_t *tmp;
+
+    if (!out || !params || !out_size) {
+        return TRUSTY_ERR_INVALID_ARGS;
+    }
+    *out_size = (sizeof(params->brand_size) +
+                 sizeof(params->device_size) +
+                 sizeof(params->product_size) +
+                 sizeof(params->serial_size) +
+                 sizeof(params->imei_size) +
+                 sizeof(params->meid_size) +
+                 sizeof(params->manufacturer_size) +
+                 sizeof(params->model_size) +
+                 params->brand_size +
+                 params->device_size +
+                 params->product_size +
+                 params->serial_size +
+                 params->imei_size +
+                 params->meid_size +
+                 params->manufacturer_size +
+                 params->model_size);
+    *out = trusty_calloc(*out_size, 1);
+    if (!*out) {
+        return TRUSTY_ERR_NO_MEMORY;
+    }
+
+    tmp = append_sized_buf_to_buf(*out, params->brand, params->brand_size);
+    tmp = append_sized_buf_to_buf(tmp, params->device, params->device_size);
+    tmp = append_sized_buf_to_buf(tmp, params->product, params->product_size);
+    tmp = append_sized_buf_to_buf(tmp, params->serial, params->serial_size);
+    tmp = append_sized_buf_to_buf(tmp, params->imei, params->imei_size);
+    tmp = append_sized_buf_to_buf(tmp, params->meid, params->meid_size);
+    tmp = append_sized_buf_to_buf(tmp, params->manufacturer, params->manufacturer_size);
+    tmp = append_sized_buf_to_buf(tmp, params->model, params->model_size);
+
+    return TRUSTY_ERR_NONE;
+}
+
 int km_attestation_data_serialize(const struct km_attestation_data *data,
                                  uint8_t** out, uint32_t *out_size)
 {


### PR DESCRIPTION
Get attestation_ids from boot config, including brand, device, product, manufacturer and model. Pass attestation_ids to trusty via KM_SET_ATTESTATION_IDS.

Tracked-On: OAM-100070
Signed-off-by: yuxincui <yuxin.cui@intel.com>