### PR TITLE
Late activate vtd

### DIFF
--- a/include/trusty_common.h
+++ b/include/trusty_common.h
@@ -36,4 +36,6 @@
 
 EFI_STATUS load_tos_image(OUT VOID **bootimage);
 
+VOID trusty_late_init(VOID);
+
 #endif /* _TRUSTY_COMMON_H_ */

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -57,6 +57,9 @@
 #ifdef USE_FIRSTSTAGE_MOUNT
 #include "firststage_mount.h"
 #endif
+#ifdef USE_TRUSTY
+#include "trusty_common.h"
+#endif
 
 #include "uefi_utils.h"
 
@@ -466,6 +469,13 @@ static inline EFI_STATUS handover_jump(EFI_HANDLE image,
         return ret;
 
 boot:
+
+#ifdef USE_TRUSTY
+        /*
+         * Called after ExitBootService.
+         */
+        trusty_late_init();
+#endif
 
 #if __LP64__
         /* The 64-bit kernel entry is 512 bytes after the start. */

--- a/libkernelflinger/trusty_common.c
+++ b/libkernelflinger/trusty_common.c
@@ -258,3 +258,17 @@ EFI_STATUS load_tos_image(OUT VOID **tosimage)
 
         return EFI_SUCCESS;
 }
+
+static VOID activate_vtd(VOID)
+{
+#define VMCALL_ACTIVATE_VTD 0x56544400ULL        // "VTD"
+        asm volatile ("vmcall" : : "a"(VMCALL_ACTIVATE_VTD));
+}
+
+/*
+ * This function is designed to run after bootloader triggered ExitBootService.
+ */
+VOID trusty_late_init(VOID)
+{
+        activate_vtd();
+}

--- a/libsslsupport/borningssl/sys/syscall.h
+++ b/libsslsupport/borningssl/sys/syscall.h
@@ -1,4 +1,5 @@
 /*
 function needed for compiling borningssl on Android O
 */
+#pragma once
 long syscall(long __number, ...){return 0;};


### PR DESCRIPTION
Add new function trusty_late_init() which is called between
ExitBootService() and kernel jumping.
Currently, only activate_vtd_vmcall() is called in trusty_late_init().

Tracked-On: OAM-101011
Signed-off-by: Yadong Qi <yadong.qi@intel.com>