### PR TITLE
fixed can't get major version of clang issues

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,12 +3,11 @@ KERNELFLINGER_CFLAGS := -Wa,--noexecstack -Wall -Wextra -Werror -mrdrnd -fwrapv
 
 ifeq (clang, $(findstring clang, $(IAFW_CC)))
 L_CC = $(IAFW_CC)
-CC_VERSION = $(shell $(L_CC) --version)
+CC_VERSION = $(shell $(L_CC) --version | head -1)
 # Clang support "-fno-delete-null-pointer-checks flags" when (version > 6)
-MAJOR_VER := $(shell echo '$(CC_VERSION)' |\
-               head -1 |\
-               sed -n 's/.*clang version \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p' |\
-               head -c 1)
+MAJOR_VER := $(shell echo '$(CC_VERSION)' | \
+               sed -n 's/.*clang version \([[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\).*/\1/p' |\
+               sed 's/\..*//g')
 
 ifeq ($(shell test $(MAJOR_VER) -gt 6; echo $$?), 0)
 KERNELFLINGER_CFLAGS += -fno-delete-null-pointer-checks


### PR DESCRIPTION
origin code only for major version < 10

the patch to support major version of clang > 9
verify with clang 11/12 passed