### PR TITLE
Add SBL support for kernelflinger

### DIFF
--- a/libfastboot/fastboot.c
+++ b/libfastboot/fastboot.c
@@ -1121,7 +1121,7 @@ static void cmd_download(INTN argc, CHAR8 **argv)
 		fastboot_fail("data too large");
 		return;
 	}
-	ui_print(L"Receiving %ld bytes ...", dl.size);
+	ui_print(L"Receiving 0x%llx bytes ...", dl.size);
 
 	len = efi_snprintf(response, sizeof(response), (CHAR8 *)"DATA%08x",
 			   dl.size);

--- a/libfastboot/flash.c
+++ b/libfastboot/flash.c
@@ -485,9 +485,11 @@ static struct label_exception {
 	{ L"kernel", flash_kernel },
 	{ L"ramdisk", flash_ramdisk },
 	{ ESP_LABEL, flash_esp },
+#ifndef USE_SBL
 	{ BOOTLOADER_LABEL, flash_bootloader },
 	{ BOOTLOADER_A_LABEL, flash_bootloader_a },
 	{ BOOTLOADER_B_LABEL, flash_bootloader_b },
+#endif
 #if defined(IOC_USE_SLCAN) || defined(IOC_USE_CBC)
 	{ L"ioc", flash_ioc },
 #endif


### PR DESCRIPTION
1. Add efiwrapper and libpayload library to support SBL
2. Reuse kerneflinger.c for SBL entry
3. Solve compile issues

Tracked-On: OAM-110183