### PR TITLE
pass ACRN cmdline parameter from sbl to os

### DIFF
--- a/include/vars.h
+++ b/include/vars.h
@@ -154,6 +154,7 @@ CHAR16 *get_reboot_reason();
 #ifdef USE_SBL
 CHAR16 *get_sbl_boot_reason();
 const char *ewarg_getval(const char *name);
+const char *get_cmd_for_kernel();
 #endif
 BOOLEAN is_reboot_reason(CHAR16 *reason);
 VOID del_reboot_reason();

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -1283,6 +1283,10 @@ static EFI_STATUS setup_command_line(
         CHAR8 *abl_cmd_line = NULL;
         BOOLEAN is_uefi = TRUE;
         UINTN abl_cmd_len = 0;
+#ifdef USE_SBL
+        const char *cmd_for_kernel = NULL;
+        char *tmp = NULL;
+#endif
 
         is_uefi = is_UEFI();
 
@@ -1357,6 +1361,17 @@ static EFI_STATUS setup_command_line(
                 if (EFI_ERROR(ret))
                         goto out;
         }
+
+#ifdef USE_SBL
+        /* Append cmd_for_kernel */
+        cmd_for_kernel = get_cmd_for_kernel();
+        tmp = (char *)cmd_for_kernel;
+        while ((tmp = strchr(tmp, '\\')) != NULL) {
+                *tmp = ' ';
+                tmp++;
+        }
+        ret = prepend_command_line(&cmdline16, L"%a", cmd_for_kernel);
+#endif
 
 #ifndef USER
         if (get_disable_watchdog()) {

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -67,6 +67,7 @@
 #define ANDROID_PROP_VALUE_MAX	92
 #define REBOOT_REASON_MAX 	64
 #define SBL_RESET_REASON "reset"
+#define CMD_FOR_KERNEL   "cmd_for_kernel"
 
 /* Default maximum number of watchdog resets in a row before the crash
  * event menu is displayed. */
@@ -883,6 +884,10 @@ CHAR16 *get_sbl_boot_reason(){
 	//convert to CHAR16
 	ret = stra_to_str((CHAR8 *)reason);
 	return ret;
+}
+
+const char *get_cmd_for_kernel(){
+    return ewarg_getval(CMD_FOR_KERNEL);
 }
 #endif
 


### PR DESCRIPTION
We will pass ACRN cmdline from SBL to OS.
Any parameter passing from cmd_for_kernel, like cmd_for_kernel=key1=value\\key2=value2 \\key3=value3 will be passed without any check as
key1=value1 key2=value2 key3=value3

Tracked-On: OAM-113545