### PR TITLE
Add a memdump function without check for NULL source to pull whole ram

### DIFF
--- a/include/lib.h
+++ b/include/lib.h
@@ -189,6 +189,11 @@ CHAR8 *itoa(int val, CHAR8 *buf, unsigned radix)
 void *memcpy(void *dest, const void *source, size_t count)
     __attribute__((weak));
 
+#ifdef CRASHMODE_USE_ADB
+EFI_STATUS memdump(void *dest, size_t dest_size, const void *source, size_t count)
+    __attribute__((weak));
+#endif
+
 EFI_STATUS memcpy_s(void *dest, size_t dest_size, const void *source, size_t count)
     __attribute__((weak));
 

--- a/libadb/adb_socket.c
+++ b/libadb/adb_socket.c
@@ -150,7 +150,12 @@ EFI_STATUS asock_write(asock_t s, unsigned char *data, UINT32 length)
 	if (!s || length > adb_max_payload)
 		return EFI_INVALID_PARAMETER;
 
+#ifdef CRASHMODE_USE_ADB
+	ret = memdump(s->data, sizeof(s->data), data, length);
+#elif
 	ret = memcpy_s(s->data, sizeof(s->data), data, length);
+#endif
+
 	if (EFI_ERROR(ret))
 		return ret;
 	s->wrt.data = s->data;

--- a/libkernelflinger/lib.c
+++ b/libkernelflinger/lib.c
@@ -1409,6 +1409,34 @@ void *memcpy(void *dest, const void *source, size_t count)
         return dest;
 }
 
+#ifdef CRASHMODE_USE_ADB
+EFI_STATUS memdump(void *dest, size_t dest_size, const void *source, size_t count)
+{
+        if (count == 0) {
+                debug(L"<memcpy_s count NULL");
+                return EFI_SUCCESS;
+        }
+
+        if (dest == NULL) {
+                error(L"<memcpy_s dest NULL");
+                return EFI_INVALID_PARAMETER;
+        }
+
+        if (dest_size < count) {
+                CopyMem(dest, 0, (UINTN)dest_size);
+                error(L"<memcpy_s BAD_BUFFER_SIZE 0x%x %d %d", source, dest_size, count);
+                return EFI_BAD_BUFFER_SIZE;
+        }
+
+        if (source == NULL) {
+                debug(L"<memcpy_s source NULL");
+        }
+
+        CopyMem(dest, source, (UINTN)count);
+        return EFI_SUCCESS;
+}
+#endif
+
 EFI_STATUS memcpy_s(void *dest, size_t dest_size, const void *source, size_t count)
 {
         if (count == 0) {


### PR DESCRIPTION
memcpy_s will report BAD_BUFFER_SIZE when source is NULL. That prevents developers from pulling the entire ram under Crashmode. This patch add a less secury function memcopy_less_s. This function just print a warning message instead of reporting an error when source is NULL.

Tracked-On: OAM-110650