### PR TITLE
Skip install dummy acpi table and remove some unused functions

### DIFF
--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -594,10 +594,12 @@ static enum boot_target choose_boot_target(CHAR16 **target_path, BOOLEAN *onesho
 	if (ret != NORMAL_BOOT)
 		goto out;
 
+#ifndef USE_SBL
 	debug(L"Bootlogic: Check battery insertion...");
 	ret = check_battery_inserted();
 	if (ret != NORMAL_BOOT)
 		goto out;
+#endif
 
 	debug(L"Bootlogic: Check BCB...");
 	ret = check_bcb(target_path, oneshot);
@@ -621,6 +623,7 @@ static enum boot_target choose_boot_target(CHAR16 **target_path, BOOLEAN *onesho
 	if (ret != DNX && ret != NORMAL_BOOT)
 		goto out;
 
+#ifndef USE_SBL
 	debug(L"Bootlogic: Check battery level...");
 	ret = check_battery();
 
@@ -636,6 +639,7 @@ static enum boot_target choose_boot_target(CHAR16 **target_path, BOOLEAN *onesho
 
 	debug(L"Bootlogic: Check charger insertion...");
 	ret = check_charge_mode();
+#endif
 
 out:
 	debug(L"Bootlogic: selected '%s'",  boot_target_description(ret));
@@ -1245,10 +1249,12 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 		}
 	}
 
+#ifndef USE_SBL
 	uefi_bios_update_capsule(g_disk_device, FWUPDATE_FILE);
 
 	uefi_check_upgrade(g_loaded_image, BOOTLOADER_LABEL, KFUPDATE_FILE,
 			BOOTLOADER_FILE, BOOTLOADER_FILE_BAK, KFSELF_FILE, KFBACKUP_FILE);
+#endif
 
 #ifdef USE_IVSHMEM
 	ret = ivshmem_init();

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -1892,7 +1892,11 @@ EFI_STATUS android_image_load_file(
                 goto out;
         }
 
+        log(L"Skip install acpi table.\n");
+
+#if 0
         ret = android_install_acpi_table();
+#endif
 
 out:
         if (delete) {

--- a/libkernelflinger/android_vb2.c
+++ b/libkernelflinger/android_vb2.c
@@ -280,6 +280,7 @@ EFI_STATUS get_avb_result(
 
 EFI_STATUS android_install_acpi_table_avb(AvbSlotVerifyData *slot_data)
 {
+#if 0
         const char *acpi_part_names[] = {
 #ifdef USE_ACPI
                 "acpi",
@@ -288,6 +289,7 @@ EFI_STATUS android_install_acpi_table_avb(AvbSlotVerifyData *slot_data)
                 "acpio",
 #endif
                 NULL};
+#endif
         VOID *image = NULL;
         EFI_STATUS ret = EFI_SUCCESS;
         struct boot_img_hdr *hdr;
@@ -306,6 +308,8 @@ EFI_STATUS android_install_acpi_table_avb(AvbSlotVerifyData *slot_data)
                 }
         }
 
+        debug(L"Skip install apci table....\n");
+#if 0
         for (int i = 0; acpi_part_names[i] != NULL; i++) {
                 ret = android_query_image_from_avb_result(slot_data,
                                                     acpi_part_names[i], &image);
@@ -321,6 +325,7 @@ EFI_STATUS android_install_acpi_table_avb(AvbSlotVerifyData *slot_data)
                         return ret;
                 }
         }
+#endif
         return ret;
 }
 


### PR DESCRIPTION
1. Some functions are useless in the bootloader running on SBL, remove these functions.
2. dummy ACPI occupies 4096 bytes, and there is no data in this dummy ACPI table. However, this dummy ACPI will overwrite other ACPI region and may result in a boot failure. To fix this issue, skip install dummy ACPI table.

Test done: Device can boot up after the OTA.

Tracked-On: OAM-115179