### PR TITLE
Restart fastboot if gets transport run error

### DIFF
--- a/libfastboot/fastboot.c
+++ b/libfastboot/fastboot.c
@@ -1507,6 +1507,11 @@ EFI_STATUS fastboot_start(void **bootimage, void **efiimage, UINTN *imagesize,
 		ret = transport_run();
 		if (EFI_ERROR(ret) && ret != EFI_TIMEOUT) {
 			efi_perror(ret, L"Error occurred during transport run");
+#ifdef USE_SBL
+			error(L"fastboot restart due to transport error");
+			cmd_reboot_bootloader(0, NULL);
+			reboot_to_target(FASTBOOT, EfiResetCold);
+#endif
 			goto exit;
 		}
 


### PR DESCRIPTION
If device meets EFI_DEVICE_ERROR while getting USB_REQ_GET_STATUS request from host. This USB error can't recover if re-init USB device. Thus all fastboot functions can't work. We need restart fastboot in case of such failure

Test Done:
fastboot can work after running 400 times below commands: fastboot reboot bootloader
fastboot devices

Tracked-On: OAM-115637