### PR TITLE
Fix static scan issues

### DIFF
--- a/avb/libavb/avb_cmdline.c
+++ b/avb/libavb/avb_cmdline.c
@@ -364,6 +364,10 @@ AvbSlotVerifyResult avb_append_options(
         // remapped by avb_manage_hashtree_error_mode().
         avb_assert_not_reached();
         break;
+      default:
+        // Handle unexpected value of resolved_hashtree_error_mode
+        avb_assert_not_reached();
+        break;
     }
     new_ret = avb_replace(
         slot_data->cmdline, "$(ANDROID_VERITY_MODE)", dm_verity_mode);


### PR DESCRIPTION
When resolved_hashtree_error_mode is unexpected value, abort the program to avoid uninitialized pointer read.

Tracked-On: OAM-118501