### PR TITLE
Add QNX vdev shm support

### DIFF
--- a/include/ivshmem.h
+++ b/include/ivshmem.h
@@ -48,6 +48,19 @@
 #define TEE_TPM2_SHOW_INDEX             0x0000000A
 #define TEE_TPM2_DELETE_INDEX           0x0000000B
 
+#define QNX_VDEV_SHM_DEV_INDEX          6
+
+struct optee_vm_ids {
+	uint32_t ree_id;
+	uint32_t tee_id;
+} __packed;
+
+typedef enum {
+	EVENT_KERNEL = 1,
+	EVENT_ROT,
+	EVENT_ROLLBACK,
+} event_src;
+
 EFI_STATUS ivshmem_init(void);
 
 void ivshmem_rot_interrupt(void);
@@ -60,5 +73,6 @@ struct tpm2_int_req {
 };
 
 void ivshmem_rollback_index_interrupt(struct tpm2_int_req* req);
+void ivshmem_detach(void);
 
 #endif /* _IVSHMEM_H_ */

--- a/include/lib.h
+++ b/include/lib.h
@@ -273,5 +273,6 @@ EFI_STATUS string_to_argv(char *str, INTN *argc, CHAR8 *argv[], UINTN max_argc,
                           const char *first_delim, const char *delim);
 
 int is_running_on_kvm(void);
+int is_running_on_qnx(void);
 #endif
 

--- a/include/qnx_guest_shm.h
+++ b/include/qnx_guest_shm.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018, QNX Software Systems Limited (“QSS”).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional Patent Grant
+ *
+ * QSS hereby grants to you a perpetual, worldwide, non-exclusive,
+ * no-charge, irrevocable (except as stated in this section) patent
+ * license to make, have made, use, offer to sell, sell, import,
+ * transfer, and otherwise run, modify and propagate the contents of this
+ * header file (“Implementation”) , where such license applies
+ * only to those patent claims, both currently owned by QSS and
+ * acquired in the future, licensable by QSS that are necessarily
+ * infringed by this Implementation. This grant does
+ * not include claims that would be infringed only as a consequence of
+ * further modification of this Implementation. If you or your agent or
+ * exclusive licensee institute or order or agree to the institution of
+ * patent litigation against any entity (including a cross-claim or
+ * counterclaim in a lawsuit) alleging that this Implementation constitutes
+ * direct or contributory patent infringement, or inducement of patent
+ * infringement, then any patent rights granted to you under this license for
+ * this Implementation shall terminate as of the date such litigation is filed.
+ *
+ * Alternatively, this software may be distributed under the terms of the
+ * GNU General Public License ("GPL") version 2 as published by the Free
+ * Software Foundation.
+ */
+
+/**
+ * @file
+ * definitions guest shared memory device
+ */
+
+#ifndef _QVM_GUEST_SHM_H
+#define _QVM_GUEST_SHM_H
+
+#include <stdint.h>
+
+/*
+ * Temporary VID definition until the updated <pci/pci_id.h> propogates around
+ */
+#define PCI_VID_BlackBerry_QNX	0x1C05
+
+#define PCI_DID_QNX_GUEST_SHM	0x0001
+
+/** status of last creation request */
+enum guest_shm_status {
+	GSS_OK,					/**< creation succeeded */
+	GSS_UNKNOWN_FAILURE,	/**< creation failed for an unknown reason */
+	GSS_NOMEM,				/**< creation failed due to lack of memory */
+	GSS_CLIENT_MAX,			/**< creation failed due to region already being used by the maximum number of guests */
+	GSS_ILLEGAL_NAME,		/**< creation failed due to illegal region name */
+	GSS_NO_PERMISSION,		/**< creation failed due to lack of permission */
+	GSS_DOES_NOT_EXIST,		/**< A find request failed */
+};
+
+/** Maximum number of clients allowed to connect to a shared memory region */
+#define GUEST_SHM_MAX_CLIENTS	16
+#define GUEST_INTR_STATUS_MASK  ((1u << GUEST_SHM_MAX_CLIENTS) - 1u)
+
+/** Maximum length allowed for region name */
+#define GUEST_SHM_MAX_NAME	32
+
+/** Signature value to verify that vdev is present */
+#define GUEST_SHM_SIGNATURE_L 0x474d5651
+#define GUEST_SHM_SIGNATURE_H 0x4d534732
+#define GUEST_SHM_SIGNATURE   0x4d534732474d5651
+
+
+/** Register layout for factory registers */
+struct guest_shm_factory {
+	UINT64		signature; /**< == GUEST_SHM_SIGNATURE (R/O) */
+	UINT64		shmem;	/**< shared memory paddr (R/O) */
+	UINT32		vector;	/**< interrupt vector number (R/O) */
+	UINT32		status; /**< status of last creation (R/O) */
+	UINT32		size;	/**< requested size in 4K pages, write causes creation */
+	CHAR8		name[GUEST_SHM_MAX_NAME];	/**< name of shared memory region */
+	UINT32		find;	/**< find an existing shared memory connection */
+} __packed;
+
+/** Register layout for a region control page */
+struct guest_shm_control {
+	UINT32		status;	/**< lower 16 bits: pending notification bitset, upper 16 bits: current active clients (R/O) */
+	UINT32		idx;	/**< connection index for this client (R/O) */
+	UINT32		notify;	/**< write a bitset of clients to notify */
+	UINT32		detach; /**< write here to detach from the shared memory region */
+};
+
+
+static inline void
+guest_shm_create(volatile struct guest_shm_factory *const __factory, UINT32 const __size) {
+	/* Surround the size assignment with memory barriers so that
+	 * the compiler doesn't try to shift the assignment before/after
+	 * necessary bits (e.g. setting the name of the region) */
+	asm volatile( "" ::: "memory");
+	__factory->size = __size;
+	asm volatile( "" ::: "memory");
+}
+
+
+static inline void
+guest_shm_find(volatile struct guest_shm_factory *const __factory, UINT32 const __find_num) {
+	/* Surround the find assignment with memory barriers so that
+	 * the compiler doesn't try to shift the assignment before/after
+	 * necessary bits (e.g. setting the name of the region) */
+	asm volatile( "" ::: "memory");
+	__factory->find = __find_num;
+	asm volatile( "" ::: "memory");
+}
+
+#endif

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -37,6 +37,7 @@
 
 #include "android.h"
 #include "efilinux.h"
+#include "ivshmem.h"
 #include "lib.h"
 #include "security.h"
 #include "vars.h"
@@ -436,6 +437,8 @@ static inline EFI_STATUS handover_jump(EFI_HANDLE image,
         UINTN map_key, i;
 
         log(L"handover jump ...\n");
+
+        ivshmem_detach();
 
         ret = setup_gdt();
         if (EFI_ERROR(ret)) {

--- a/libkernelflinger/lib.c
+++ b/libkernelflinger/lib.c
@@ -1739,5 +1739,16 @@ int is_running_on_kvm(void)
     return 0;
 }
 
+int is_running_on_qnx(void)
+{
+    UINT32 reg[4];
+
+    cpuid(0x40000000, reg);
+    if (reg[0] == 0x40000002 && reg[1] == 0x51584e51 && reg[2] == 0x53424d56 && reg[3] == 0x4751)
+        return 1;
+
+    return 0;
+}
+
 /* vim: softtabstop=8:shiftwidth=8:expandtab
  */


### PR DESCRIPTION
On QNX platform, kernelflinger can sync with OPTEE by using qnx vdev shm mechanism.

Tracked-On: OAM-123671