### PR TITLE
Boot device to normal mode if no USB connection

### DIFF
--- a/include/adb.h
+++ b/include/adb.h
@@ -68,7 +68,7 @@ typedef struct adb_pkt {
 } adb_pkt_t;
 
 EFI_STATUS adb_init();
-EFI_STATUS adb_run();
+EFI_STATUS adb_run(UINT32 *state);
 EFI_STATUS adb_exit();
 enum boot_target adb_get_boot_target(void);
 void adb_set_boot_target(enum boot_target bt);

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -40,7 +40,7 @@ EFI_STATUS tcp_start(UINT32 port, start_callback_t start_cb,
 		     data_callback_t rx_cb, data_callback_t tx_cb,
 		     EFI_IPv4_ADDRESS *station_address);
 EFI_STATUS tcp_stop(void);
-EFI_STATUS tcp_run(void);
+EFI_STATUS tcp_run(UINT32 *state);
 EFI_STATUS tcp_read(void *buf, UINT32 size);
 EFI_STATUS tcp_write(void *buf, UINT32 size);
 

--- a/include/transport.h
+++ b/include/transport.h
@@ -46,7 +46,7 @@ typedef struct transport {
 			    data_callback_t rx_cb,
 			    data_callback_t tx_cb);
 	EFI_STATUS (*stop)(void);
-	EFI_STATUS (*run)(void);
+	EFI_STATUS (*run)(UINT32 *state);
 	EFI_STATUS (*read)(void *buf, UINT32 size);
 	EFI_STATUS (*write)(void *buf, UINT32 size);
 } transport_t;
@@ -58,7 +58,7 @@ EFI_STATUS transport_start(start_callback_t start_cb,
 			   data_callback_t rx_cb,
 			   data_callback_t tx_cb);
 EFI_STATUS transport_stop(void);
-EFI_STATUS transport_run(void);
+EFI_STATUS transport_run(UINT32 *state);
 EFI_STATUS transport_read(void *buf, UINT32 len);
 EFI_STATUS transport_write(void *buf, UINT32 len);
 

--- a/include/usb.h
+++ b/include/usb.h
@@ -45,7 +45,7 @@ EFI_STATUS usb_start(UINT8 subclass,
 		     data_callback_t rx_cb,
 		     data_callback_t tx_cb);
 EFI_STATUS usb_stop(void);
-EFI_STATUS usb_run(void);
+EFI_STATUS usb_run(UINT32 *state);
 EFI_STATUS usb_read(void *buf, UINT32 size);
 EFI_STATUS usb_write(void *buf, UINT32 size);
 

--- a/kf4abl.c
+++ b/kf4abl.c
@@ -94,7 +94,7 @@ static EFI_STATUS enter_crashmode(enum boot_target *target)
 
 	debug(L"adb implementation is initialized");
 	for (;;) {
-		ret = adb_run();
+		ret = adb_run(NULL);
 		if (EFI_ERROR(ret))
 			break;
 

--- a/libadb/adb.c
+++ b/libadb/adb.c
@@ -420,11 +420,13 @@ EFI_STATUS adb_init()
 	return transport_start(adb_read_msg, adb_process_rx, adb_process_tx);
 }
 
-EFI_STATUS adb_run()
+EFI_STATUS adb_run(UINT32 *state)
 {
 	EFI_STATUS ret;
 
-	ret = transport_run();
+	if(state)
+		*state = 1;
+	ret = transport_run(NULL);
 	if (EFI_ERROR(ret) && ret != EFI_TIMEOUT) {
 		efi_perror(ret, L"Error occurred during USB run");
 		return ret;

--- a/libefitcp/tcp.c
+++ b/libefitcp/tcp.c
@@ -614,11 +614,13 @@ EFI_STATUS tcp_stop(void)
 	return EFI_SUCCESS;
 }
 
-EFI_STATUS tcp_run(void)
+EFI_STATUS tcp_run(UINT32 *state)
+
 {
 	if (!tcp_connection)
 		return EFI_SUCCESS;
-
+	if (state)
+		*state = 1;
 	return uefi_call_wrapper(tcp_connection->Poll, 1,
 				 tcp_connection);
 }

--- a/libefiusb/protocol/UsbDeviceModeProtocol.h
+++ b/libefiusb/protocol/UsbDeviceModeProtocol.h
@@ -82,7 +82,8 @@ typedef
 EFI_STATUS
 (EFIAPI *EFI_USB_DEVICE_MODE_RUN) (
 	IN EFI_USB_DEVICE_MODE_PROTOCOL               *This,
-	IN UINT32                                     TimeoutMs
+	IN UINT32                                     TimeoutMs,
+	UINT32 *state
 	);
 
 ///

--- a/libefiusb/usb.c
+++ b/libefiusb/usb.c
@@ -450,7 +450,7 @@ EFI_STATUS usb_stop(void)
 	return ret;
 }
 
-EFI_STATUS usb_run(void)
+EFI_STATUS usb_run(UINT32 *state)
 {
-	return uefi_call_wrapper(usb_device->Run, 2, usb_device, 1);
+	return uefi_call_wrapper(usb_device->Run, 2, usb_device, 1, state);
 }

--- a/libtransport/transport.c
+++ b/libtransport/transport.c
@@ -97,9 +97,9 @@ EFI_STATUS transport_stop(void)
 	return ret;
 }
 
-EFI_STATUS transport_run(void)
+EFI_STATUS transport_run(UINT32 *state)
 {
-	return current ? current->run() : EFI_NOT_STARTED;
+	return current ? current->run(state) : EFI_NOT_STARTED;
 }
 
 EFI_STATUS transport_read(void *buf, UINT32 size)

--- a/ux.c
+++ b/ux.c
@@ -513,7 +513,7 @@ enum boot_target ux_prompt_user_for_boot_target(enum ux_error_code code) {
 	while (1) {
 #ifdef CRASHMODE_USE_ADB
 		if (adb_initialized) {
-			ret = adb_run();
+			ret = adb_run(NULL);
 			if (EFI_ERROR(ret))
 				break;
 


### PR DESCRIPTION
If there is no USB connection in bootloader fastboot mode, device should enter to normal mode after timeout.

Test Done:
Boot, flash, boot to normal mode after USB timeout

Tracked-On: OAM-123898