### PR TITLE
coverity fix for Boot in kernelflinger

### DIFF
--- a/libadb/reader.c
+++ b/libadb/reader.c
@@ -728,7 +728,7 @@ static EFI_STATUS efivar_find(CHAR16 *varname, EFI_GUID *guid_p)
 	EFI_STATUS ret;
 	UINTN bufsize, namesize;
 	CHAR16 *name;
-	EFI_GUID guid;
+	EFI_GUID guid={0};
 	BOOLEAN found = FALSE;
 	EFI_GUID found_guid;
 

--- a/libefiusb/device_mode/UsbDeviceMode.c
+++ b/libefiusb/device_mode/UsbDeviceMode.c
@@ -135,7 +135,7 @@ UsbdInit (
   )
 {
   EFI_STATUS               Status = EFI_DEVICE_ERROR;
-  USB_DEV_CONFIG_PARAMS    ConfigParams;
+  USB_DEV_CONFIG_PARAMS    ConfigParams = {0};
 
   XhciSwitchSwid(TRUE);
 
@@ -280,7 +280,7 @@ UsbdEpTxData (
   )
 {
   EFI_STATUS        Status = EFI_DEVICE_ERROR;
-  USB_XFER_REQUEST  TxReq;
+  USB_XFER_REQUEST  TxReq = {0};
 
   //
   //set endpoint data
@@ -328,7 +328,7 @@ UsbdEpRxData (
   )
 {
   EFI_STATUS        Status = EFI_DEVICE_ERROR;
-  USB_XFER_REQUEST  RxReq;
+  USB_XFER_REQUEST  RxReq = {0};
   UINT32            ReqPacket;
 
   DEBUG ((DEBUG_INFO,  "RX REQUEST in: IoReq->IoInfo.Length: 0x%x\n", IoReq->IoInfo.Length));

--- a/libfastboot/bootmgr.c
+++ b/libfastboot/bootmgr.c
@@ -81,7 +81,7 @@ static EFI_STATUS find_load_option_entry(CHAR16 *description, UINT16 *entry)
 	EFI_STATUS ret;
 	UINTN bufsize, namesize;
 	CHAR16 *name;
-	EFI_GUID guid;
+	EFI_GUID guid = {0};
 	CHAR8 number[5];
 	UINTN size;
 	EFI_LOAD_OPTION *load_option;

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -434,7 +434,7 @@ EFI_STATUS erase_efivars(VOID)
 	EFI_STATUS ret;
 	UINTN bufsize, namesize;
 	CHAR16 *name;
-	EFI_GUID guid;
+	EFI_GUID guid = {0};
 	UINTN i;
 
 	bufsize = 64;		/* Initial size large enough to handle

--- a/libsslsupport/wrapper.c
+++ b/libsslsupport/wrapper.c
@@ -422,7 +422,7 @@ struct tm *gmtime_r(const int64_t *timep, struct tm *tmp)
 		tdelta = tdays / DAYSPERLYEAR;
 		if (tdelta < INT_MIN || tdelta > INT_MAX)
 			return NULL;
-		idelta = tdelta;
+		idelta = (int)tdelta;
 		if (idelta == 0)
 			idelta = (tdays < 0) ? -1 : 1;
 		newy = y;


### PR DESCRIPTION
Addressed high priority coverity issues related to Memory corruptions, Uninitialized variables
and Memory illegal accesses.

Test done:
Build and boot android success.

Tracked-On: OAM-122325