### PR TITLE
coverity issue fix for Boot in kernelflinger

### DIFF
--- a/libfastboot/bootmgr.c
+++ b/libfastboot/bootmgr.c
@@ -84,7 +84,7 @@ static EFI_STATUS find_load_option_entry(CHAR16 *description, UINT16 *entry)
 	EFI_GUID guid = {0};
 	CHAR8 number[5];
 	UINTN size;
-	EFI_LOAD_OPTION *load_option;
+	EFI_LOAD_OPTION *load_option = NULL;
 	UINT32 flags;
 
 	bufsize = 64;		/* Initial size large enough to handle

--- a/libkernelflinger/fatfs/source/ff.c
+++ b/libkernelflinger/fatfs/source/ff.c
@@ -5192,7 +5192,7 @@ FRESULT f_rename (
 {
 	FRESULT res;
 	FATFS *fs;
-	DIR djo, djn;
+	DIR djn = {0}, djo = {0};
 	BYTE buf[FF_FS_EXFAT ? SZDIRE * 2 : SZDIRE], *dir;
 	LBA_t sect;
 	DEF_NAMBUF


### PR DESCRIPTION
Addressed high priority coverity issues related toi Uninitialized variables.

Test done:
Build and boot android success.

Tracked-On: OAM-124618