### PR TITLE
Med-coverity issue fix for Boot in kernelflinger

### DIFF
--- a/installer.c
+++ b/installer.c
@@ -225,7 +225,7 @@ static EFI_STATUS installer_flash_big_chunk_multiple(EFI_FILE **file, UINTN *rea
 
 	for (ckh_blks = ckh->chunk_sz; ckh_blks; ckh_blks -= ckh->chunk_sz) {
 		ckh->chunk_sz = min(MAX_BLKS, ckh_blks);
-		data_size = ckh->chunk_sz * fb->sph.blk_sz;
+		data_size = (UINTN)ckh->chunk_sz * (UINTN)fb->sph.blk_sz;
 		ckh->total_sz = sizeof(*ckh) + data_size;
 		fb->sph.total_blks = fb->skip_ckh.chunk_sz + ckh->chunk_sz;
 		installer_flash_buffer(fb, ckh->total_sz + HEADER_SIZE, argc, argv);
@@ -290,7 +290,7 @@ static EFI_STATUS installer_flash_big_chunk(EFI_FILE *file, UINTN *remaining_dat
 
 	for (ckh_blks = ckh->chunk_sz; ckh_blks; ckh_blks -= ckh->chunk_sz) {
 		ckh->chunk_sz = min(MAX_BLKS, ckh_blks);
-		data_size = ckh->chunk_sz * fb->sph.blk_sz;
+		data_size = (UINTN)ckh->chunk_sz * (UINTN)fb->sph.blk_sz;
 		ckh->total_sz = sizeof(*ckh) + data_size;
 		fb->sph.total_blks = fb->skip_ckh.chunk_sz + ckh->chunk_sz;
 

--- a/libfastboot/flash.c
+++ b/libfastboot/flash.c
@@ -678,7 +678,7 @@ EFI_STATUS garbage_disk(void)
 		return ret;
 	}
 
-	size = p_gparti->bio->Media->BlockSize * N_BLOCK;
+	size = (UINTN)(p_gparti->bio->Media->BlockSize) * N_BLOCK;
 	ret = alloc_aligned(&chunk, &aligned_chunk, size, p_gparti->bio->Media->IoAlign);
 	if (EFI_ERROR(ret)) {
 		efi_perror(ret, L"Unable to allocate the garbage chunk");

--- a/libkernelflinger/ui.c
+++ b/libkernelflinger/ui.c
@@ -627,11 +627,11 @@ void ui_bilinear_scale(unsigned char *s, unsigned char *d,
 			int y1 = y;
 			int y2 = y1 + 1;
 			for (k = 0; k < depth; k++) {
-				d[j * depth + i * dx * depth + k] = (1 / ((x2 - x1) * (y2 - y1))) *
+				d[j * depth + i * dx * depth + k] =(int)((1 / ((x2 - x1) * (y2 - y1))) *
 					(s[x1 * depth + y1 * sx + k] * (x2 - x) * (y2 - y) +
 					 s[x2 * depth + y1 * sx + k] * (x - x1) * (y2 - y) +
 					 s[x1 * depth + y2 * sx + k] * (x2 - x) * (y - y1) +
-					 s[x2 * depth + y2 * sx + k] * (x - x1) * (y - y1));
+					 s[x2 * depth + y2 * sx + k] * (x - x1) * (y - y1)));
 			}
 		}
 }

--- a/libkernelflinger/ui_textarea.c
+++ b/libkernelflinger/ui_textarea.c
@@ -102,12 +102,12 @@ static void ui_textarea_copy_char(unsigned char *src_p, UINTN src_row_bytes,
 		unsigned char* px = dst_p;
 		for (i = 0; i < width; ++i) {
 			unsigned char a = *sx++;
-			if (a == 255) {
+			if (a == 255 && color) {
 				*px++ = color->Blue;
 				*px++ = color->Green;
 				*px++ = color->Red;
 				px++;
-			} else if (a > 0) {
+			} else if (a > 0 && color) {
 				*px = (*px * (255-a) + color->Blue * a) / 255;
 				++px;
 				*px = (*px * (255-a) + color->Green * a) / 255;


### PR DESCRIPTION
Addressed Medium priority coverity issues related to Explicit null dereferenced & integer overflow

Test done:
Build and boot android success.

Tracked-On: OAM-122118