### PR TITLE
WA- Fix BM user build not flashing issue

### DIFF
--- a/libfastboot/fastboot_flashing.c
+++ b/libfastboot/fastboot_flashing.c
@@ -257,13 +257,13 @@ static void cmd_unlock(__attribute__((__unused__)) INTN argc,
 #endif
 		change_device_state(UNLOCKED, TRUE);
 	} else {
-#ifdef USER
-		fastboot_fail("Unlocking device not allowed");
-#else
+//#ifdef USER
+//		fastboot_fail("Unlocking device not allowed");
+//#else
 		fastboot_info("Unlock protection is set");
 		fastboot_info("Unlocking anyway since this is not a User build");
 		change_device_state(UNLOCKED, TRUE);
-#endif
+//#endif
 	}
 }
 


### PR DESCRIPTION
Set device to unlocked state to enable BM user build flashing on MTL-NUC.This is a WA patch and needs to be revisited after trusty is enabled.

Test Done: BM user build boots on MTL NUC

Tracked-On: NA