### PR TITLE
Revert "fix coverity issue for Boot in kernelflinger - 2", removing 182 only

### DIFF
--- a/libadb/reader.c
+++ b/libadb/reader.c
@@ -523,6 +523,7 @@ static EFI_STATUS vmcore_build_header(reader_ctx_t *ctx, void *priv_p)
 
 		if (priv->m.end && end > priv->m.end) {
 			length -= end - priv->m.end;
+			end = priv->m.end;
 		}
 
 		priv->hdr.phnum++;
@@ -580,7 +581,7 @@ static EFI_STATUS vmcore_read(reader_ctx_t *ctx, unsigned char **buf, UINT64 *le
 
 	/* Start new memory region */
 	if (priv->m.cur == priv->m.cur_end) {
-		if (priv->cur_phdr >= priv->hdr.phnum - 1) {
+		if (priv->cur_phdr == priv->hdr.phnum - 1) {
 			error(L"Invalid parameter in %a", __func__);
 			return EFI_INVALID_PARAMETER;
 		}

--- a/libfastboot/flash.c
+++ b/libfastboot/flash.c
@@ -659,12 +659,10 @@ EFI_STATUS erase_by_label(CHAR16 *label)
 	if (!CompareGuid(&p_gparti->part.type, &EfiPartTypeSystemPartitionGuid))
 		return gpt_refresh();
 
-#ifdef USER
 	if (is_data)
 		userdata_erased = TRUE;
 	if (is_share_data)
 		share_data_erased = TRUE;
-#endif
 
 	return EFI_SUCCESS;
 }

--- a/libkernelflinger/fatfs/source/ff.c
+++ b/libkernelflinger/fatfs/source/ff.c
@@ -5171,7 +5171,7 @@ FRESULT f_mkdir (
 					res = sync_fs(fs);
 				}
 			} else {
-				res = remove_chain(&sobj, dcl, 0);		/* Could not register, remove the allocated cluster */
+				remove_chain(&sobj, dcl, 0);		/* Could not register, remove the allocated cluster */
 			}
 		}
 		FREE_NAMBUF();


### PR DESCRIPTION
This reverts commit fc32d32a2a2952482c26151791b8cd9219d2fb4e.