### PR TITLE
Revert "Make device as unlocked state by default on userdebug build f…

### DIFF
--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -1528,7 +1528,9 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 #ifndef USER
 	/* WA patch to set device as unlocked by default for userdebug build
 	 */
+#ifdef USE_SBL
 	set_current_state(UNLOCKED);
+#endif
 #else
 	/* For civ, flash images to disk is not MUST. So set device to LOCKED
 	 * state by default on the first boot.


### PR DESCRIPTION
…or civ"

This reverts commit 0f7383ffe04d70b938893a06aa6f5295eab78acd.

Tracked-On: NA
Signed-off-by: NA