### PR TITLE
BSP_DIFF cleanup

### DIFF
--- a/libsslsupport/Android.mk
+++ b/libsslsupport/Android.mk
@@ -107,8 +107,8 @@ include $(LOCAL_PATH)/android-config.mk
 LOCAL_SRC_FILES := $(LOCAL_SRC_FILES_$(LOCAL_ARCH))
 endif
 ifneq (,$(filter boringssl, $(KERNELFLINGER_SSL_LIBRARY)))
-include $(LOCAL_PATH)/sources.mk
-LOCAL_SRC_FILES := $(crypto_sources) $(linux_$(LOCAL_ARCH)_sources)
+include $(LOCAL_PATH)/crypto-sources.mk
+LOCAL_SRC_FILES += $(crypto_sources) $(linux_$(LOCAL_ARCH)_sources)
 #ifeq ($(FIRST_BUILD_ID),O)
 LOCAL_C_INCLUDES += $(KERNELFLINGER_SSLSUPPORT_PATH)/borningssl
 LOCAL_CFLAGS += -I$(KERNELFLINGER_SSLSUPPORT_PATH)/borningssl


### PR DESCRIPTION
Observed build error due to missing multiple crypto sources reference. Adding crypto sources.

Tests done: Prepared EB and there is no build error.

Tracked-On: OAM-127806