### PR TITLE
Support userbuild parameter for security

### DIFF
--- a/crashdump.c
+++ b/crashdump.c
@@ -41,6 +41,7 @@
 
 BOOLEAN tee_tpm = 0;
 BOOLEAN andr_tpm = 0;
+BOOLEAN user_build = false;
 
 static struct gpt_partition_interface gparti;
 static UINT64 cur_offset;

--- a/include/android.h
+++ b/include/android.h
@@ -32,6 +32,7 @@
 #define BOOT_ARGS_SIZE 512
 #define BOOT_EXTRA_ARGS_SIZE 1024
 
+BOOLEAN user_build;
 
 struct boot_img_hdr
 {

--- a/installer.c
+++ b/installer.c
@@ -77,6 +77,8 @@ BOOLEAN andr_tpm = true;
 BOOLEAN andr_tpm = false;
 #endif
 
+BOOLEAN user_build = false;
+
 #define inst_perror(ret, x, ...) do { \
 	fastboot_fail(x ": %r", ##__VA_ARGS__, ret); \
 } while (0)

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -80,6 +80,8 @@ BOOLEAN andr_tpm = true;
 BOOLEAN andr_tpm = false;
 #endif
 
+BOOLEAN user_build = false;
+
 /* Ensure this is embedded in the EFI binary somewhere */
 static const CHAR16 __attribute__((used)) magic[] = L"### kernelflinger ###";
 
@@ -542,7 +544,8 @@ static enum boot_target check_command_line()
 		BOOTREASON,
 		FIRMWARE_STATUS,
 		OPTEE,
-		TPM
+		TPM,
+		USERBLD
 	};
 
 	struct Cmdline
@@ -607,6 +610,11 @@ static enum boot_target check_command_line()
 			(CHAR8 *)"tpm=",
 			strlen((CHAR8 *)"tpm="),
 			TPM
+		},
+		{
+			(CHAR8 *)"userbuild=",
+			strlen((CHAR8 *)"userbuild="),
+			USERBLD
 		},
 
 	};
@@ -751,6 +759,18 @@ static enum boot_target check_command_line()
 						andr_tpm = false;
 					continue;
 				}
+				case USERBLD: {
+					UINT8 val;
+					nptr = (CHAR8 *)(arg8 + CmdlineArray[j].length);
+					val = (UINT8)strtoul((char *)nptr, 0, 10);
+					debug(L"Android user = %u\n", val);
+					if (val)
+						user_build = true;
+					else
+						user_build = false;
+					continue;
+				}
+
 				default:
 					continue;
 				}

--- a/libfastboot/fastboot_flashing.c
+++ b/libfastboot/fastboot_flashing.c
@@ -271,9 +271,14 @@ static void cmd_unlock(__attribute__((__unused__)) INTN argc,
 #ifdef USER
 		fastboot_fail("Unlocking device not allowed");
 #else
-		fastboot_info("Unlock protection is set");
-		fastboot_info("Unlocking anyway since this is not a User build");
-		change_device_state(UNLOCKED, TRUE);
+		/* user_build is from boot parameters to compatible for CIV and IVI */
+		if (user_build) {
+			fastboot_fail("Unlocking device not allowed");
+		} else {
+			fastboot_info("Unlock protection is set");
+			fastboot_info("Unlocking anyway since this is not a User build");
+			change_device_state(UNLOCKED, TRUE);
+		}
 #endif
 	}
 }

--- a/libkernelflinger/storage.c
+++ b/libkernelflinger/storage.c
@@ -78,7 +78,7 @@ static EFI_STATUS identify_storage(EFI_DEVICE_PATH *device_path,
 				   struct storage **storage,
 				   enum storage_type *type)
 {
-	enum storage_type st;
+	enum storage_type st = STORAGE_EMMC;
 	static struct storage *supported_storage[STORAGE_ALL] = {
 		&STORAGE(STORAGE_EMMC)
 		, &STORAGE(STORAGE_UFS)
@@ -92,7 +92,10 @@ static EFI_STATUS identify_storage(EFI_DEVICE_PATH *device_path,
 		, &STORAGE(STORAGE_GENERAL_BLOCK)
 	};
 
-	for (st = STORAGE_EMMC; st < STORAGE_ALL; st++) {
+#ifdef USE_SBL
+	st = STORAGE_NVME;
+#endif
+	for (; st < STORAGE_ALL; st++) {
 		if ((filter == st || filter == STORAGE_ALL) &&
 		    supported_storage[st] && supported_storage[st]->probe(device_path)) {
 			debug(L"%s storage identified", supported_storage[st]->name);


### PR DESCRIPTION
In user build, device can't be unlock if unlock_ability is failue. unlock_ablility can be set via developer settings.

Tracked-On: OAM-127732