### PR TITLE
Display boot reason in fastboot UI

### DIFF
--- a/include/android.h
+++ b/include/android.h
@@ -579,6 +579,7 @@ EFI_STATUS prepend_slot_command_line(CHAR16 **cmdline16,
 UINTN get_vb_cmdlen(VBDATA *vb_data);
 
 char *get_vb_cmdline(VBDATA *vb_data);
+const char *get_boot_reason_string(void);
 #endif
 
 /* vim: softtabstop=8:shiftwidth=8:expandtab

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -1591,10 +1591,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	reboot_to_target(NORMAL_BOOT, EfiResetCold);
 #endif
 
-#ifdef __FORCE_FASTBOOT
-	enter_fastboot_mode(boot_state);
-#endif
-
 	/* No UX prompts before this point, do not want to interfere
 	 * with magic key detection
 	 */
@@ -1698,6 +1694,9 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	boot_state = BOOT_STATE_RED;
 #endif
 
+#ifdef __FORCE_FASTBOOT
+	enter_fastboot_mode(boot_state);
+#endif
 	/* EFI binaries are validated by the BIOS */
 	if (boot_target == ESP_EFI_BINARY) {
 		debug(L"entering EFI binary");

--- a/libfastboot/fastboot_ui.c
+++ b/libfastboot/fastboot_ui.c
@@ -42,6 +42,7 @@
 #include "fastboot_ui.h"
 #include "smbios.h"
 #include "info.h"
+#include "android.h"
 
 static const ui_textline_t unlocked_headers[] = {
 	{ &COLOR_WHITE,		"        Unlock bootloader?",			TRUE },
@@ -158,7 +159,8 @@ struct info_text_fun {
 	{ "IFWI VERSION",	fastboot_ui_info_ifwi_version,	fastboot_ui_default_color },
 	{ "SERIAL NUMBER",	fastboot_ui_info_serial_number,	fastboot_ui_default_color },
 	{ "SECURE BOOT",	fastboot_ui_info_secure_boot,	fastboot_ui_info_secure_boot_color },
-	{ "LOCK STATE",		get_current_state_string,	get_current_state_color }
+	{ "LOCK STATE",		get_current_state_string,	get_current_state_color },
+	{ "BOOT REASON",	get_boot_reason_string,		fastboot_ui_default_color }
 };
 
 static const char *FASTBOOT_TITLE = "FASTBOOT MODE";

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -917,8 +917,35 @@ static CHAR16 *get_boot_reason(void)
         }
 
 done:
+#ifndef USE_SBL
         del_reboot_reason();
+#endif
         return bootreason;
+}
+
+const char *get_boot_reason_string(void)
+{
+	CHAR16 *reason16;
+	char *reason8;
+	EFI_STATUS ret;
+	UINTN len;
+
+	reason16 = get_boot_reason();
+	if (!reason16)
+		return "unknown";
+
+	len = StrLen(reason16);
+	reason8 = AllocatePool(len + 1);
+	if (!reason8)
+		return "unknown";
+
+	ret = str_to_stra(reason8, reason16, len + 1);
+	if (EFI_ERROR(ret)) {
+		error(L"Non-ascii characters found");
+		return "unknown";
+	}
+
+	return reason8;
 }
 
 EFI_STATUS prepend_command_line(CHAR16 **cmdline, CHAR16 *fmt, ...)


### PR DESCRIPTION
Support UI display for boot reason

Test Done:
Boot

Tracked-On: OAM-132083